### PR TITLE
Assign variable to variable "salida" in order to avoid runtime errors

### DIFF
--- a/libhtts/src/wordchop.cpp
+++ b/libhtts/src/wordchop.cpp
@@ -285,7 +285,10 @@ CtI WdChop::parserEmo(pCHAR fltbuff, BOOL flush)
 
 	//Salida de la función.
 	CtI salida;
-
+	
+	// Asigna un valor a salida para evitar errores runtime
+	salida = ct.lastGrp();
+	
 	if (flush)
 	{
 		if (labelStarted)


### PR DESCRIPTION
My windows compilation throws a runtime error because salida is not premptively assigned a value. Although, later on the value assignment for "salida" is handled in several "if" branches, it can potentially lead to a null value.